### PR TITLE
Fix 'utf-8' fallback encoding for RSS feed

### DIFF
--- a/src/AppStudio.DataProviders/Core/HttpRequest.cs
+++ b/src/AppStudio.DataProviders/Core/HttpRequest.cs
@@ -146,6 +146,7 @@ namespace AppStudio.DataProviders.Core
                     }
                 }
             }
+            SetEncoding(response);
         }
 
         private static void SetEncoding(HttpResponseMessage response)


### PR DESCRIPTION
Fixing https://github.com/wasteam/waslibs/issues/62 issue